### PR TITLE
add a 3 sec sleep between each thread.start()

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -165,3 +165,4 @@ def bootstrap(config: dict):
 
     for thread in threads:
         thread.start()
+        sleep(3)


### PR DESCRIPTION
if you thread.start() too fast with mutiple accounts, some of them won't load